### PR TITLE
#2: Self-update command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           - os: ubuntu-latest
             rid: linux-x64
             asset: mill-linux-x64
-          - os: macos-13
+          - os: macos-15-intel
             rid: osx-x64
             asset: mill-osx-x64
-          - os: macos-14
+          - os: macos-latest
             rid: osx-arm64
             asset: mill-osx-arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+            asset: mill-win-x64.exe
+          - os: ubuntu-latest
+            rid: linux-x64
+            asset: mill-linux-x64
+          - os: macos-13
+            rid: osx-x64
+            asset: mill-osx-x64
+          - os: macos-14
+            rid: osx-arm64
+            asset: mill-osx-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: publish
+        run: dotnet publish cli/mill-cli.csproj -c Release -r ${{ matrix.rid }} -o out
+
+      - name: rename artifact
+        shell: bash
+        run: |
+          if [[ "${{ matrix.rid }}" == win-* ]]; then
+            mv out/mill.exe out/${{ matrix.asset }}
+          else
+            mv out/mill out/${{ matrix.asset }}
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: out/${{ matrix.asset }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
           - os: windows-latest
             rid: win-x64
             asset: mill-win-x64.exe
+          - os: windows-11-arm
+            rid: win-arm64
+            asset: mill-win-arm64.exe
           - os: ubuntu-latest
             rid: linux-x64
             asset: mill-linux-x64

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build outputs
 bin/
 obj/
+out/
 cli/bin/
 cli/obj/
 

--- a/.mill/memory/issue-2-plan.md
+++ b/.mill/memory/issue-2-plan.md
@@ -1,0 +1,14 @@
+# Slice Plan for #2
+
+## Concerns
+- [x] Config - Version in csproj
+- [x] Model - GitHub release API types, version info
+- [x] Logic - Version reading, platform detection, GitHub API, download/replace
+- [ ] Interface - CLI commands (`--version`, `update`, `update --check`)
+
+## Slice Order
+1. **Config + Model** - Add `<Version>` to csproj, add GitHub release API types (GhRelease, GhAsset). Foundation for everything else.
+2. **Logic** - Implement version reading, platform detection, GitHub API fetch, download, and self-replacement. The core functionality.
+3. **Interface** - Wire up CLI: `--version` flag, `update` command, `update --check` flag. Also add old binary cleanup on startup.
+
+## Current: Slice 2 (complete)

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -5,8 +5,14 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
+// Clean up old binary from previous update (silent, on every run)
+Updater.CleanupOldBinary();
+
 return args switch
 {
+    ["--version"] or ["-v"] => ShowVersion(),
+    ["update", "--check"] => await RunUpdateCheck(),
+    ["update"] => await RunUpdate(),
     ["init"] => await Mill.Init(),
     ["spec", ..] => await Mill.RunSpec(),
     ["personas"] => Mill.RunPersonas(),
@@ -16,6 +22,75 @@ return args switch
     ["run"] => Mill.ListAvailableIssues(),
     _ => ShowHelp()
 };
+
+static int ShowVersion()
+{
+    Console.WriteLine($"mill {Mill.Version}");
+    return 0;
+}
+
+static async Task<int> RunUpdateCheck()
+{
+    var check = await Updater.Check();
+
+    Console.WriteLine($"  current: {check.Current}");
+
+    if (check.Error != null)
+    {
+        Out.Error($"failed to check for updates: {check.Error}");
+        return 1;
+    }
+
+    Console.WriteLine($"  latest:  {check.Latest}");
+    Out.Blank();
+
+    if (check.UpdateAvailable)
+    {
+        Console.WriteLine("  run `mill update` to install");
+    }
+    else
+    {
+        Out.Ok($"already at latest ({check.Current})");
+    }
+
+    return 0;
+}
+
+static async Task<int> RunUpdate()
+{
+    var check = await Updater.Check();
+
+    Console.WriteLine($"  current: {check.Current}");
+
+    if (check.Error != null)
+    {
+        Out.Error($"failed to check for updates: {check.Error}");
+        return 1;
+    }
+
+    if (!check.UpdateAvailable)
+    {
+        Out.Blank();
+        Out.Ok($"already at latest ({check.Current})");
+        return 0;
+    }
+
+    Console.WriteLine($"  latest:  {check.Latest}");
+    Out.Blank();
+
+    var (success, message) = await Updater.Apply();
+
+    if (success)
+    {
+        Out.Ok(message);
+        return 0;
+    }
+    else
+    {
+        Out.Error(message);
+        return 1;
+    }
+}
 
 static int ShowHelp()
 {
@@ -29,6 +104,9 @@ static int ShowHelp()
           mill run                list available issues
           mill run --auto         autopick best issue (health check + scoring)
           mill run 123            execute work loop on GitHub issue
+          mill update             update mill to latest version
+          mill update --check     check for updates without installing
+          mill --version          show version
         """);
     return 0;
 }

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -1658,8 +1658,15 @@ static class Updater
     static async Task<GhRelease?> FetchLatestRelease()
     {
         var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
-        var json = await Http.GetStringAsync(url);
-        return JsonSerializer.Deserialize(json, GhJsonContext.Default.GhRelease);
+        try
+        {
+            var json = await Http.GetStringAsync(url);
+            return JsonSerializer.Deserialize(json, GhJsonContext.Default.GhRelease);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null; // no releases published yet
+        }
     }
 
     /// <summary>

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -1425,6 +1427,16 @@ record GhIssueDetail(
 
 record GhLabel([property: JsonPropertyName("name")] string Name);
 
+// GitHub Releases API types
+record GhRelease(
+    [property: JsonPropertyName("tag_name")] string TagName,
+    [property: JsonPropertyName("assets")] List<GhAsset> Assets);
+
+record GhAsset(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("size")] long Size,
+    [property: JsonPropertyName("browser_download_url")] string BrowserDownloadUrl);
+
 // MILL configuration
 record MillConfig
 {
@@ -1461,6 +1473,7 @@ record HealthConfig
 
 [JsonSerializable(typeof(List<GhIssue>))]
 [JsonSerializable(typeof(GhIssueDetail))]
+[JsonSerializable(typeof(GhRelease))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class GhJsonContext : JsonSerializerContext { }
 

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -49,6 +49,30 @@ static class Out
 
 static partial class Mill
 {
+    /// <summary>
+    /// Gets the current mill version from assembly metadata.
+    /// Falls back to "unknown" if not available.
+    /// </summary>
+    public static string Version =>
+        Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion?.Split('+')[0] ?? "unknown";
+
+    /// <summary>
+    /// Gets the expected GitHub release asset name for the current platform.
+    /// </summary>
+    public static string AssetName
+    {
+        get
+        {
+            var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win"
+                   : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx"
+                   : "linux";
+            var arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+            return os == "win" ? $"mill-{os}-{arch}.exe" : $"mill-{os}-{arch}";
+        }
+    }
+
     // Parent git root - cached at startup, never changes (used for config, standards, drafts)
     static string? _parentGitRoot;
     static string ParentGitRoot => _parentGitRoot ??= ResolveGitRoot();
@@ -1412,6 +1436,170 @@ static partial class Mill
 
     [GeneratedRegex(@"PICK:(\d+)")]
     private static partial Regex PickPattern();
+}
+
+/// <summary>
+/// Self-update logic: fetch latest release from GitHub, download, and replace the running binary.
+/// </summary>
+static class Updater
+{
+    const string RepoOwner = "mindrevolution";
+    const string RepoName = "mill";
+    static readonly HttpClient Http = new()
+    {
+        DefaultRequestHeaders =
+        {
+            { "User-Agent", "mill" },
+            { "Accept", "application/vnd.github.v3+json" }
+        }
+    };
+
+    /// <summary>
+    /// Check result: current vs latest version.
+    /// </summary>
+    public record UpdateCheck(string Current, string? Latest, bool UpdateAvailable, string? Error);
+
+    /// <summary>
+    /// Checks for updates by querying the GitHub Releases API.
+    /// </summary>
+    public static async Task<UpdateCheck> Check()
+    {
+        var current = Mill.Version;
+        try
+        {
+            var release = await FetchLatestRelease();
+            if (release == null)
+                return new UpdateCheck(current, null, false, "no releases available");
+
+            var latest = release.TagName.TrimStart('v');
+            var updateAvailable = CompareVersions(current, latest) < 0;
+            return new UpdateCheck(current, latest, updateAvailable, null);
+        }
+        catch (HttpRequestException ex)
+        {
+            var message = ex.StatusCode == System.Net.HttpStatusCode.Forbidden
+                ? "rate limited — try again later"
+                : $"connection failed: {ex.Message}";
+            return new UpdateCheck(current, null, false, message);
+        }
+        catch (Exception ex)
+        {
+            return new UpdateCheck(current, null, false, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Downloads and installs the latest version.
+    /// </summary>
+    public static async Task<(bool Success, string Message)> Apply()
+    {
+        var check = await Check();
+        if (check.Error != null)
+            return (false, check.Error);
+
+        if (!check.UpdateAvailable)
+            return (true, $"already at latest ({check.Current})");
+
+        try
+        {
+            var release = await FetchLatestRelease();
+            if (release == null)
+                return (false, "no releases available");
+
+            var assetName = Mill.AssetName;
+            var asset = release.Assets.FirstOrDefault(a => a.Name == assetName);
+            if (asset == null)
+                return (false, $"no binary for {assetName}");
+
+            // Download to temp file
+            var exePath = Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location;
+            var exeDir = Path.GetDirectoryName(exePath)!;
+            var tmpPath = Path.Combine(exeDir, assetName + ".tmp");
+
+            Out.Step($"downloading {assetName}...");
+
+            using (var response = await Http.GetAsync(asset.BrowserDownloadUrl, HttpCompletionOption.ResponseHeadersRead))
+            {
+                response.EnsureSuccessStatusCode();
+                await using var fs = File.Create(tmpPath);
+                await response.Content.CopyToAsync(fs);
+            }
+
+            // Verify download size
+            var downloadedSize = new FileInfo(tmpPath).Length;
+            if (downloadedSize == 0 || downloadedSize != asset.Size)
+            {
+                File.Delete(tmpPath);
+                return (false, "download corrupted — size mismatch");
+            }
+
+            // Self-replace using rename trick
+            var oldPath = exePath + ".old";
+
+            // Remove leftover .old from previous update (might fail if locked, that's ok)
+            try { File.Delete(oldPath); } catch { /* ignore */ }
+
+            // Rename current → old, tmp → current
+            File.Move(exePath, oldPath);
+            File.Move(tmpPath, exePath);
+
+            // On Unix, set executable bit
+            if (!OperatingSystem.IsWindows())
+            {
+                var chmod = Process.Start("chmod", ["+x", exePath]);
+                chmod?.WaitForExit();
+            }
+
+            return (true, $"updated to {check.Latest}");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return (false, "permission denied — check install location");
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Cleans up old binary from previous update. Call on startup.
+    /// </summary>
+    public static void CleanupOldBinary()
+    {
+        try
+        {
+            var exePath = Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location;
+            var oldPath = exePath + ".old";
+            if (File.Exists(oldPath))
+                File.Delete(oldPath);
+        }
+        catch { /* silently ignore */ }
+    }
+
+    static async Task<GhRelease?> FetchLatestRelease()
+    {
+        var url = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
+        var json = await Http.GetStringAsync(url);
+        return JsonSerializer.Deserialize(json, GhJsonContext.Default.GhRelease);
+    }
+
+    /// <summary>
+    /// Compares semantic versions. Returns negative if a &lt; b, 0 if equal, positive if a &gt; b.
+    /// </summary>
+    static int CompareVersions(string a, string b)
+    {
+        var aParts = a.Split('.').Select(s => int.TryParse(s, out var n) ? n : 0).ToArray();
+        var bParts = b.Split('.').Select(s => int.TryParse(s, out var n) ? n : 0).ToArray();
+
+        for (var i = 0; i < Math.Max(aParts.Length, bParts.Length); i++)
+        {
+            var av = i < aParts.Length ? aParts[i] : 0;
+            var bv = i < bParts.Length ? bParts[i] : 0;
+            if (av != bv) return av.CompareTo(bv);
+        }
+        return 0;
+    }
 }
 
 record GhIssue(

--- a/cli/mill-cli.csproj
+++ b/cli/mill-cli.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>13</LangVersion>
+    <Version>0.1.0</Version>
 
     <!-- AOT -->
     <PublishAot>true</PublishAot>

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = "Stop"
+Push-Location $PSScriptRoot
+
+try {
+    $rid = "win-x64"
+    $installDir = "$env:LOCALAPPDATA\Programs\mill"
+    $target = "$installDir\mill.exe"
+
+    Write-Host "  > building for $rid"
+    dotnet publish cli/mill-cli.csproj -c Release -r $rid -o out --nologo -v q
+
+    Write-Host "  > installing to $target"
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    Copy-Item "out/mill.exe" $target -Force
+
+    Write-Host "  ✓ installed" -ForegroundColor Green
+
+    # check if in PATH
+    $paths = $env:PATH -split ";"
+    if ($paths -notcontains $installDir) {
+        Write-Host ""
+        Write-Host "  ! $installDir not in PATH" -ForegroundColor Yellow
+        Write-Host "  run once to add:"
+        Write-Host "    [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$installDir', 'User')"
+    }
+}
+finally {
+    Pop-Location
+}

--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,9 @@ $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot
 
 try {
-    $rid = "win-x64"
+    # detect architecture
+    $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "arm64" } else { "x64" }
+    $rid = "win-$arch"
     $installDir = "$env:LOCALAPPDATA\Programs\mill"
     $target = "$installDir\mill.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# detect platform
+case "$(uname -s)" in
+    Darwin) os="osx" ;;
+    Linux)  os="linux" ;;
+    *)      echo "  x unsupported OS"; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+    arm64|aarch64) arch="arm64" ;;
+    x86_64)        arch="x64" ;;
+    *)             echo "  x unsupported architecture"; exit 1 ;;
+esac
+
+rid="$os-$arch"
+install_dir="$HOME/.local/bin"
+target="$install_dir/mill"
+
+echo "  > building for $rid"
+dotnet publish cli/mill-cli.csproj -c Release -r "$rid" -o out --nologo -v q
+
+echo "  > installing to $target"
+mkdir -p "$install_dir"
+cp out/mill "$target"
+chmod +x "$target"
+
+echo "  ✓ installed"
+
+# check if in PATH
+if ! command -v mill &>/dev/null; then
+    echo ""
+    echo "  ! ~/.local/bin not in PATH"
+    echo "  add to your shell profile:"
+    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+fi

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,8 +1,0 @@
-$ErrorActionPreference = "Stop"
-Push-Location $PSScriptRoot
-try {
-    dotnet publish cli/mill-cli.csproj -c Release -o bin
-}
-finally {
-    Pop-Location
-}

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,14 +1,8 @@
 $ErrorActionPreference = "Stop"
-
-dotnet publish cli/mill-cli.csproj -c Release -o bin
-
-$binPath = (Resolve-Path "bin").Path
-$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-
-if ($userPath -notlike "*$binPath*") {
-    [Environment]::SetEnvironmentVariable("Path", "$userPath;$binPath", "User")
-    $env:Path = "$env:Path;$binPath"
-    Write-Host "  + added $binPath to PATH"
-} else {
-    Write-Host "  . $binPath already in PATH"
+Push-Location $PSScriptRoot
+try {
+    dotnet publish cli/mill-cli.csproj -c Release -o bin
+}
+finally {
+    Pop-Location
 }

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-dotnet publish cli/mill-cli.csproj -c Release -o bin

--- a/release.ps1
+++ b/release.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = "Stop"
+Push-Location $PSScriptRoot
+
+try {
+    # extract version from csproj
+    $csproj = Get-Content "cli/mill-cli.csproj" -Raw
+    $version = [regex]::Match($csproj, '<Version>([^<]+)</Version>').Groups[1].Value
+    $tag = "v$version"
+
+    Write-Host "  > preparing release $tag"
+
+    # validate clean state
+    $status = git status --porcelain
+    if ($status) {
+        Write-Host "  x working directory not clean" -ForegroundColor Red
+        exit 1
+    }
+
+    # check if tag exists
+    $existing = git rev-parse $tag 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  x tag $tag already exists" -ForegroundColor Red
+        exit 1
+    }
+
+    # create and push tag
+    git tag $tag
+    Write-Host "  ✓ created tag $tag" -ForegroundColor Green
+
+    git push origin $tag
+    Write-Host "  ✓ pushed to origin" -ForegroundColor Green
+
+    Write-Host ""
+    Write-Host "  release workflow triggered"
+    Write-Host "  https://github.com/mindrevolution/mill/actions"
+}
+finally {
+    Pop-Location
+}

--- a/release.ps1
+++ b/release.ps1
@@ -9,10 +9,17 @@ try {
 
     Write-Host "  > preparing release $tag"
 
-    # validate clean state
-    $status = git status --porcelain
+    # warn if not on main branch
+    $branch = git rev-parse --abbrev-ref HEAD
+    if ($branch -ne "dev" -and $branch -ne "main") {
+        Write-Host "  ! on branch '$branch', not dev/main" -ForegroundColor Yellow
+        Read-Host "  press enter to continue or ctrl+c to abort"
+    }
+
+    # validate no uncommitted changes (untracked files are ok)
+    $status = git status --porcelain -uno
     if ($status) {
-        Write-Host "  x working directory not clean" -ForegroundColor Red
+        Write-Host "  x uncommitted changes" -ForegroundColor Red
         exit 1
     }
 

--- a/release.sh
+++ b/release.sh
@@ -9,9 +9,16 @@ tag="v$version"
 
 echo "  > preparing release $tag"
 
-# validate clean state
-if [[ -n $(git status --porcelain) ]]; then
-    echo "  x working directory not clean"
+# warn if not on main branch
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$branch" != "dev" && "$branch" != "main" ]]; then
+    echo "  ! on branch '$branch', not dev/main"
+    read -p "  press enter to continue or ctrl+c to abort"
+fi
+
+# validate no uncommitted changes (untracked files are ok)
+if [[ -n $(git status --porcelain -uno) ]]; then
+    echo "  x uncommitted changes"
     exit 1
 fi
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# extract version from csproj
+version=$(grep -oP '(?<=<Version>)[^<]+' cli/mill-cli.csproj)
+tag="v$version"
+
+echo "  > preparing release $tag"
+
+# validate clean state
+if [[ -n $(git status --porcelain) ]]; then
+    echo "  x working directory not clean"
+    exit 1
+fi
+
+# check if tag exists
+if git rev-parse "$tag" >/dev/null 2>&1; then
+    echo "  x tag $tag already exists"
+    exit 1
+fi
+
+# create and push tag
+git tag "$tag"
+echo "  ✓ created tag $tag"
+
+git push origin "$tag"
+echo "  ✓ pushed to origin"
+
+echo ""
+echo "  release workflow triggered"
+echo "  https://github.com/mindrevolution/mill/actions"


### PR DESCRIPTION
Fixes #2

## Summary
Implemented self-update functionality: (1) version in csproj with runtime reading, (2) GitHub Releases API types and Updater class with download/replace logic, (3) CLI commands (--version, update, update --check) with old binary cleanup on startup

## Verification
Build succeeds. All CLI commands tested: --version shows version, update --check and update handle missing releases gracefully with proper error messages, help displays new commands