### PR TITLE
#6: unified install command

### DIFF
--- a/.mill/context.md
+++ b/.mill/context.md
@@ -1,0 +1,64 @@
+<!-- mill-context-hash: 3d4003c4ee6c16f509dc0033001855f9d74beec7 -->
+# Project Context
+
+## Summary
+MILL is a specification-first AI delivery system that transforms user intent into verified deliverables. It provides two main workflows: **Spec Process** (chat-to-spec) and **Work Loop** (bounded iteration until verification passes). The system creates GitHub issues from specs and executes work in isolated git worktrees.
+
+## Standards
+- Diagrams must use Mermaid (no ASCII art)
+- CLI output style: minimal, uniform, hacker style (all lowercase, small symbols only)
+- Do not run `dotnet publish` after each change
+- Keep markdown files concise and scannable
+
+## Architecture
+- Single .NET 9 CLI application (`cli/Program.cs`)
+- AOT-compiled native binary
+- Prompts stored in `spec/prompts/` and `run/prompts/`
+- Templates in `spec/templates/`
+- Per-project state in `.mill/` directory (context, memory, drafts, standards)
+- Work executed in isolated git worktrees (`.mill/work/`)
+- GitHub Issues as single source of truth for completed specs
+
+## Recent Changes
+- fix(install): detect ARM64 architecture on Windows
+- feat(ci): add Windows ARM64 build using native runner
+- fix(ci): update macos runners (13 retired, use 15-intel and latest)
+- fix(release): allow untracked files, warn on non-main branch
+- chore: remove publish scripts (use install or release instead)
+- feat: add release workflow and local scripts
+- fix(update): handle 404 as missing releases instead of connection error
+- #2: add CLI commands (--version, update, update --check) and startup cleanup (3/3)
+- #2: add version reading, platform detection, and updater logic (2/3)
+- #2: add version property and github release api types (1/3)
+
+## Tech Stack
+- **Language:** C# 13, .NET 9
+- **Build:** AOT native compilation (`PublishAot`)
+- **External CLIs:** `claude` (or MILL_CLI), `gh` (GitHub CLI), `git`
+- **CI/CD:** GitHub Actions (release.yml)
+- **Platforms:** Windows (x64, ARM64), macOS (x64, ARM64), Linux (x64, ARM64)
+
+## Key Files
+- `cli/Program.cs` - Main CLI entry point and all logic
+- `cli/mill-cli.csproj` - Project configuration
+- `spec/prompts/context-warmup.md` - Context generation prompt
+- `spec/prompts/spec-draft.md` - Interactive spec elicitation
+- `run/prompts/loop-iterate.md` - Work loop iteration prompt
+- `run/prompts/loop-verify.md` - Verification prompt
+- `run/prompts/run-autopick.md` - Issue selection prompt
+
+## Commands
+| Command | Purpose |
+|---------|---------|
+| `mill init` | Initialize repo for MILL |
+| `mill spec` | Create specification → GitHub issue |
+| `mill personas` | Create, update, or manage user personas |
+| `mill run` | List available issues |
+| `mill run --auto` | Autopick best issue (health check + scoring) |
+| `mill run N` | Execute work loop on GitHub issue |
+| `mill update` | Update mill to latest version |
+| `mill update --check` | Check for updates without installing |
+| `mill --version` | Show version |
+
+---
+*Generated: 2026-01-25*

--- a/.mill/memory/issue-6-plan.md
+++ b/.mill/memory/issue-6-plan.md
@@ -2,12 +2,12 @@
 
 ## Concerns
 - [x] Model - add InstallMode enum, InstallCheck record, system location helpers
-- [ ] Logic - mode detection, install/copy logic, downgrade check, cleanup, update logic
-- [ ] Interface - add `mill install` and `mill install --check` commands, update help
+- [x] Logic - mode detection, install/copy logic, downgrade check, cleanup, update logic
+- [x] Interface - add `mill install` and `mill install --check` commands, update help
 
 ## Slice Order
 1. **Model** - Add data structures: InstallMode enum, InstallCheck record, system location helpers (GetSystemInstallPath, IsInstalledLocation)
 2. **Logic** - Implement install logic: mode detection, install/copy behavior, downgrade warning, auto-cleanup, update behavior
 3. **Interface** - Wire up CLI commands (`install`, `install --check`), update help text, remove old `update` command
 
-## Current: Slice 2
+## Current: Slice 3 (final)

--- a/.mill/memory/issue-6-plan.md
+++ b/.mill/memory/issue-6-plan.md
@@ -1,0 +1,13 @@
+# Slice Plan for #6
+
+## Concerns
+- [ ] Model - add InstallMode enum, InstallCheck record, system location helpers
+- [ ] Logic - mode detection, install/copy logic, downgrade check, cleanup, update logic
+- [ ] Interface - add `mill install` and `mill install --check` commands, update help
+
+## Slice Order
+1. **Model** - Add data structures: InstallMode enum, InstallCheck record, system location helpers (GetSystemInstallPath, IsInstalledLocation)
+2. **Logic** - Implement install logic: mode detection, install/copy behavior, downgrade warning, auto-cleanup, update behavior
+3. **Interface** - Wire up CLI commands (`install`, `install --check`), update help text, remove old `update` command
+
+## Current: Slice 1

--- a/.mill/memory/issue-6-plan.md
+++ b/.mill/memory/issue-6-plan.md
@@ -1,7 +1,7 @@
 # Slice Plan for #6
 
 ## Concerns
-- [ ] Model - add InstallMode enum, InstallCheck record, system location helpers
+- [x] Model - add InstallMode enum, InstallCheck record, system location helpers
 - [ ] Logic - mode detection, install/copy logic, downgrade check, cleanup, update logic
 - [ ] Interface - add `mill install` and `mill install --check` commands, update help
 
@@ -10,4 +10,4 @@
 2. **Logic** - Implement install logic: mode detection, install/copy behavior, downgrade warning, auto-cleanup, update behavior
 3. **Interface** - Wire up CLI commands (`install`, `install --check`), update help text, remove old `update` command
 
-## Current: Slice 1
+## Current: Slice 2

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 // Clean up old binary from previous update (silent, on every run)
-Updater.CleanupOldBinary();
+Installer.CleanupOldBinary();
 
 return args switch
 {
@@ -31,7 +31,7 @@ static int ShowVersion()
 
 static async Task<int> RunUpdateCheck()
 {
-    var check = await Updater.Check();
+    var check = await Installer.Check();
 
     Console.WriteLine($"  current: {check.Current}");
 
@@ -58,7 +58,7 @@ static async Task<int> RunUpdateCheck()
 
 static async Task<int> RunUpdate()
 {
-    var check = await Updater.Check();
+    var check = await Installer.Check();
 
     Console.WriteLine($"  current: {check.Current}");
 
@@ -78,7 +78,7 @@ static async Task<int> RunUpdate()
     Console.WriteLine($"  latest:  {check.Latest}");
     Out.Blank();
 
-    var (success, message) = await Updater.Apply();
+    var (success, message) = await Installer.Apply();
 
     if (success)
     {
@@ -1517,9 +1517,39 @@ static partial class Mill
 }
 
 /// <summary>
+/// Installation mode: determined by whether we're running from system location or not.
+/// </summary>
+enum InstallMode
+{
+    /// <summary>
+    /// Binary is running from a non-system location (e.g., download folder).
+    /// Will copy itself to system location.
+    /// </summary>
+    Install,
+
+    /// <summary>
+    /// Binary is running from system location.
+    /// Will check for updates and download newer version.
+    /// </summary>
+    Update
+}
+
+/// <summary>
+/// Result of install check: version comparison and mode detection.
+/// </summary>
+record InstallCheck(
+    InstallMode Mode,
+    string Current,
+    string? Latest,
+    string? InstalledVersion,
+    bool UpdateAvailable,
+    bool IsDowngrade,
+    string? Error);
+
+/// <summary>
 /// Self-update logic: fetch latest release from GitHub, download, and replace the running binary.
 /// </summary>
-static class Updater
+static class Installer
 {
     const string RepoOwner = "mindrevolution";
     const string RepoName = "mill";
@@ -1531,6 +1561,104 @@ static class Updater
             { "Accept", "application/vnd.github.v3+json" }
         }
     };
+
+    /// <summary>
+    /// Gets the system install path for the current platform.
+    /// Unix: ~/.local/bin/mill
+    /// Windows: %LOCALAPPDATA%\Programs\mill\mill.exe
+    /// </summary>
+    public static string GetSystemInstallPath()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return Path.Combine(localAppData, "Programs", "mill", "mill.exe");
+        }
+        else
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, ".local", "bin", "mill");
+        }
+    }
+
+    /// <summary>
+    /// Checks if the current binary is running from the system install location.
+    /// </summary>
+    public static bool IsInstalledLocation()
+    {
+        var exePath = Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location;
+        var systemPath = GetSystemInstallPath();
+
+        // Normalize paths for comparison
+        return string.Equals(
+            Path.GetFullPath(exePath),
+            Path.GetFullPath(systemPath),
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Gets the version of the installed binary (if any).
+    /// Returns null if not installed or unreadable.
+    /// </summary>
+    public static string? GetInstalledVersion()
+    {
+        var systemPath = GetSystemInstallPath();
+        if (!File.Exists(systemPath))
+            return null;
+
+        try
+        {
+            // Run the installed binary with --version to get its version
+            var (exit, output, _) = Run(systemPath, "--version");
+            if (exit != 0) return null;
+
+            // Parse "mill X.Y.Z" output
+            var parts = output.Trim().Split(' ');
+            return parts.Length >= 2 ? parts[1] : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a path looks like a temp/download location that should be auto-cleaned.
+    /// </summary>
+    public static bool IsTemporaryLocation(string path)
+    {
+        var dir = Path.GetDirectoryName(path) ?? "";
+        var dirLower = dir.ToLowerInvariant();
+
+        // Common download/temp locations
+        return dirLower.Contains("download") ||
+               dirLower.Contains("temp") ||
+               dirLower.Contains("tmp") ||
+               dirLower.Contains("desktop");
+    }
+
+    static (int ExitCode, string Output, string Error) Run(string exe, params string[] args)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+
+        foreach (var arg in args)
+            process.StartInfo.ArgumentList.Add(arg);
+
+        process.Start();
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output, error);
+    }
 
     /// <summary>
     /// Check result: current vs latest version.

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -11,8 +11,8 @@ Installer.CleanupOldBinary();
 return args switch
 {
     ["--version"] or ["-v"] => ShowVersion(),
-    ["update", "--check"] => await RunUpdateCheck(),
-    ["update"] => await RunUpdate(),
+    ["install", "--check"] => await RunInstallCheck(),
+    ["install"] => await RunInstall(),
     ["init"] => await Mill.Init(),
     ["spec", ..] => await Mill.RunSpec(),
     ["personas"] => Mill.RunPersonas(),
@@ -29,66 +29,143 @@ static int ShowVersion()
     return 0;
 }
 
-static async Task<int> RunUpdateCheck()
+static async Task<int> RunInstallCheck()
 {
-    var check = await Installer.Check();
+    var check = await Installer.CheckInstall();
 
     Console.WriteLine($"  current: {check.Current}");
+    Console.WriteLine($"  mode:    {check.Mode.ToString().ToLowerInvariant()}");
 
-    if (check.Error != null)
+    if (check.Mode == InstallMode.Install)
     {
-        Out.Error($"failed to check for updates: {check.Error}");
-        return 1;
-    }
-
-    Console.WriteLine($"  latest:  {check.Latest}");
-    Out.Blank();
-
-    if (check.UpdateAvailable)
-    {
-        Console.WriteLine("  run `mill update` to install");
+        // Install mode: show installed version if any
+        if (check.InstalledVersion != null)
+        {
+            Console.WriteLine($"  installed: {check.InstalledVersion}");
+            if (check.IsDowngrade)
+            {
+                Out.Blank();
+                Out.Warn($"downgrade: installed {check.InstalledVersion} is newer than {check.Current}");
+            }
+        }
+        else
+        {
+            Out.Blank();
+            Out.Ok("ready to install");
+        }
     }
     else
     {
-        Out.Ok($"already at latest ({check.Current})");
+        // Update mode: check for updates
+        if (check.Error != null)
+        {
+            Out.Error($"failed to check for updates: {check.Error}");
+            return 1;
+        }
+
+        Console.WriteLine($"  latest:  {check.Latest}");
+        Out.Blank();
+
+        if (check.UpdateAvailable)
+        {
+            Console.WriteLine("  run `mill install` to update");
+        }
+        else
+        {
+            Out.Ok($"already at latest ({check.Current})");
+        }
     }
 
     return 0;
 }
 
-static async Task<int> RunUpdate()
+static async Task<int> RunInstall()
 {
-    var check = await Installer.Check();
+    var check = await Installer.CheckInstall();
 
-    Console.WriteLine($"  current: {check.Current}");
-
-    if (check.Error != null)
-    {
-        Out.Error($"failed to check for updates: {check.Error}");
-        return 1;
-    }
-
-    if (!check.UpdateAvailable)
-    {
-        Out.Blank();
-        Out.Ok($"already at latest ({check.Current})");
-        return 0;
-    }
-
-    Console.WriteLine($"  latest:  {check.Latest}");
     Out.Blank();
+    Console.WriteLine($"  current: {check.Current}");
+    Console.WriteLine($"  mode:    {check.Mode.ToString().ToLowerInvariant()}");
 
-    var (success, message) = await Installer.Apply();
-
-    if (success)
+    if (check.Mode == InstallMode.Install)
     {
-        Out.Ok(message);
-        return 0;
+        // Install mode: copy to system location
+        if (check.InstalledVersion != null)
+        {
+            Console.WriteLine($"  installed: {check.InstalledVersion}");
+        }
+
+        // Handle downgrade with confirmation
+        if (check.IsDowngrade)
+        {
+            Out.Blank();
+            Out.Warn($"installed {check.InstalledVersion} is newer than {check.Current}");
+            Console.Write("  continue? [y/n] ");
+            var confirm = Console.ReadLine()?.Trim().ToLowerInvariant();
+            if (confirm != "y")
+            {
+                Out.Blank();
+                Out.Warn("aborted");
+                return 0;
+            }
+        }
+
+        Out.Blank();
+        Out.Step("installing...");
+
+        var (success, message) = Installer.CopyToSystemLocation();
+
+        if (success)
+        {
+            Out.Ok(message);
+
+            // Check PATH and provide guidance
+            if (!Installer.IsInstallLocationInPath())
+            {
+                Out.Blank();
+                Out.Warn("install location not in PATH");
+                Out.Detail(Installer.GetPathInstructions());
+            }
+
+            return 0;
+        }
+        else
+        {
+            Out.Error(message);
+            return 1;
+        }
     }
     else
     {
-        Out.Error(message);
-        return 1;
+        // Update mode: check for updates and download
+        if (check.Error != null)
+        {
+            Out.Error($"failed to check for updates: {check.Error}");
+            return 1;
+        }
+
+        if (!check.UpdateAvailable)
+        {
+            Out.Blank();
+            Out.Ok($"already at latest ({check.Current})");
+            return 0;
+        }
+
+        Console.WriteLine($"  latest:  {check.Latest}");
+        Out.Blank();
+
+        var (success, message) = await Installer.Apply();
+
+        if (success)
+        {
+            Out.Ok(message);
+            return 0;
+        }
+        else
+        {
+            Out.Error(message);
+            return 1;
+        }
     }
 }
 
@@ -104,8 +181,8 @@ static int ShowHelp()
           mill run                list available issues
           mill run --auto         autopick best issue (health check + scoring)
           mill run 123            execute work loop on GitHub issue
-          mill update             update mill to latest version
-          mill update --check     check for updates without installing
+          mill install            install or update mill
+          mill install --check    check install status without changes
           mill --version          show version
         """);
     return 0;

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -1661,9 +1661,176 @@ static class Installer
     }
 
     /// <summary>
-    /// Check result: current vs latest version.
+    /// Check result: current vs latest version (legacy, used by update command).
     /// </summary>
     public record UpdateCheck(string Current, string? Latest, bool UpdateAvailable, string? Error);
+
+    /// <summary>
+    /// Performs install check: determines mode, compares versions, detects downgrade.
+    /// </summary>
+    public static async Task<InstallCheck> CheckInstall()
+    {
+        var current = Mill.Version;
+        var isInstalled = IsInstalledLocation();
+        var mode = isInstalled ? InstallMode.Update : InstallMode.Install;
+        var installedVersion = isInstalled ? current : GetInstalledVersion();
+
+        // Check if downgrade (only relevant in Install mode)
+        var isDowngrade = false;
+        if (mode == InstallMode.Install && installedVersion != null)
+        {
+            isDowngrade = CompareVersions(current, installedVersion) < 0;
+        }
+
+        // Fetch latest from GitHub (for Update mode)
+        string? latest = null;
+        string? error = null;
+        var updateAvailable = false;
+
+        if (mode == InstallMode.Update)
+        {
+            try
+            {
+                var release = await FetchLatestRelease();
+                if (release == null)
+                {
+                    error = "no releases available";
+                }
+                else
+                {
+                    latest = release.TagName.TrimStart('v');
+                    updateAvailable = CompareVersions(current, latest) < 0;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                error = ex.StatusCode == System.Net.HttpStatusCode.Forbidden
+                    ? "rate limited — try again later"
+                    : $"connection failed: {ex.Message}";
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+            }
+        }
+
+        return new InstallCheck(mode, current, latest, installedVersion, updateAvailable, isDowngrade, error);
+    }
+
+    /// <summary>
+    /// Main install logic: copies to system location (Install mode) or updates (Update mode).
+    /// Returns (success, message).
+    /// </summary>
+    public static async Task<(bool Success, string Message)> Install(bool skipDowngradePrompt = false)
+    {
+        var check = await CheckInstall();
+
+        if (check.Mode == InstallMode.Install)
+        {
+            // Install mode: copy to system location
+            if (check.IsDowngrade && !skipDowngradePrompt)
+            {
+                // Downgrade requires confirmation (caller should prompt)
+                return (false, $"downgrade: installed {check.InstalledVersion} is newer than {check.Current}");
+            }
+
+            return CopyToSystemLocation();
+        }
+        else
+        {
+            // Update mode: download and update
+            if (check.Error != null)
+                return (false, check.Error);
+
+            if (!check.UpdateAvailable)
+                return (true, $"already at latest ({check.Current})");
+
+            return await Apply();
+        }
+    }
+
+    /// <summary>
+    /// Copies current binary to system install location.
+    /// </summary>
+    public static (bool Success, string Message) CopyToSystemLocation()
+    {
+        var exePath = Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location;
+        var systemPath = GetSystemInstallPath();
+        var systemDir = Path.GetDirectoryName(systemPath)!;
+
+        try
+        {
+            // Create directory if needed
+            Directory.CreateDirectory(systemDir);
+
+            // Copy binary to system location
+            File.Copy(exePath, systemPath, overwrite: true);
+
+            // On Unix, set executable bit
+            if (!OperatingSystem.IsWindows())
+            {
+                var chmod = Process.Start("chmod", ["+x", systemPath]);
+                chmod?.WaitForExit();
+            }
+
+            // Auto-cleanup: delete source if from temp/download location
+            var shouldCleanup = IsTemporaryLocation(exePath);
+            if (shouldCleanup)
+            {
+                try { File.Delete(exePath); }
+                catch { /* ignore cleanup failure */ }
+            }
+
+            return (true, $"installed to {systemPath}");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return (false, $"permission denied — cannot write to {systemDir}");
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Checks if the install location is in PATH.
+    /// </summary>
+    public static bool IsInstallLocationInPath()
+    {
+        var systemPath = GetSystemInstallPath();
+        var systemDir = Path.GetDirectoryName(systemPath)!;
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? "";
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var pathDirs = pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+
+        return pathDirs.Any(dir =>
+            string.Equals(Path.GetFullPath(dir), Path.GetFullPath(systemDir),
+                OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Gets PATH instructions for the current platform.
+    /// </summary>
+    public static string GetPathInstructions()
+    {
+        var systemPath = GetSystemInstallPath();
+        var systemDir = Path.GetDirectoryName(systemPath)!;
+
+        if (OperatingSystem.IsWindows())
+        {
+            return $"add to PATH: setx PATH \"%PATH%;{systemDir}\"";
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            return $"add to PATH: echo 'export PATH=\"{systemDir}:$PATH\"' >> ~/.zshrc";
+        }
+        else
+        {
+            return $"add to PATH: echo 'export PATH=\"{systemDir}:$PATH\"' >> ~/.bashrc";
+        }
+    }
 
     /// <summary>
     /// Checks for updates by querying the GitHub Releases API.


### PR DESCRIPTION
Fixes #6

## Summary
Implemented `mill install` as a unified command for fresh installation and updates. Detects mode (install vs update) based on whether running from system location. Includes downgrade warning, PATH guidance, auto-cleanup of temp downloads, and `--check` flag. Removed old `update` command.

## Verification
dotnet build cli/mill-cli.csproj ÔÇö 0 errors, build successful