### PR TITLE
#3: Add standards inference and `mill standards` command

### DIFF
--- a/.mill/memory/issue-3-plan.md
+++ b/.mill/memory/issue-3-plan.md
@@ -1,0 +1,29 @@
+# Slice Plan for #3
+
+> Enable MILL to auto-generate codebase standards during init and refine them interactively via a new `mill standards` command.
+
+## Concerns
+- [ ] Model - N/A (no new data structures needed)
+- [ ] Logic - Standards inference logic (detecting config files, analyzing codebase patterns)
+- [ ] Interface - CLI command `mill standards`, Init integration
+- [ ] Integration - Hook standards inference into `mill init` after context warmup
+- [ ] Tests - Build verification
+- [ ] Config/Docs - Prompt file for standards inference
+
+## Slice Order
+1. **Prompt** - Create `spec/prompts/standards-infer.md` with inference logic
+   - Detects `.editorconfig`, `.eslintrc`, `stylecop.json`, `tsconfig.json`, etc.
+   - Analyzes codebase for patterns
+   - Outputs structured `.mill/standards/code.md`
+   - Why first: This is the core logic, CLI just invokes it
+
+2. **CLI** - Add `mill standards` command + integrate into `mill init`
+   - New command routing for `["standards"]`
+   - New `RunStandards()` method (similar to `RunPersonas()`)
+   - Modify `Init()` to call standards inference after context warmup
+   - Idempotent: preserve existing content, merge new inferences
+
+3. **Build Verification** - Run `dotnet build` to verify compilation
+
+## Current: Slice 1
+Creating standards-infer.md prompt file.

--- a/.mill/memory/issue-3-plan.md
+++ b/.mill/memory/issue-3-plan.md
@@ -25,5 +25,5 @@
 
 3. **Build Verification** - Run `dotnet build` to verify compilation
 
-## Current: Slice 1
-Creating standards-infer.md prompt file.
+## Current: Slice 2
+Adding CLI command and Init integration.

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -1963,10 +1963,10 @@ static partial class Mill
         process.StandardInput.Close();
 
         // Parse streaming JSON and extract text content
-        while (!process.StandardOutput.EndOfStream)
+        string? line;
+        while ((line = await process.StandardOutput.ReadLineAsync()) is not null)
         {
-            var line = await process.StandardOutput.ReadLineAsync();
-            if (string.IsNullOrEmpty(line)) continue;
+            if (line.Length == 0) continue;
 
             try
             {

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -22,6 +22,7 @@ return args switch
     ["spec", var issue] when int.TryParse(issue, out _) => await Mill.RunSpecRefine(issue),
     ["spec", ..] => await Mill.RunSpec(),
     ["personas"] => Mill.RunPersonas(),
+    ["standards"] => Mill.RunStandards(),
     ["run", "--auto"] => await Mill.RunAutopick(),
     ["run", "-a"] => await Mill.RunAutopick(),
     ["run", var issue, ..] => await Mill.Execute(issue, args),
@@ -161,6 +162,7 @@ static int ShowHelp()
           mill spec               create specification → GitHub issue
           mill spec <number>      refine existing spec against codebase
           mill personas           create or update user personas
+          mill standards          infer or update codebase standards
 
           mill run                list available issues
           mill run --auto         autopick best issue
@@ -462,12 +464,36 @@ static partial class Mill
             Out.Ok("CLAUDE.md shim created");
         }
 
+        // Auto-infer standards if not present
+        var standardsFile = Path.Combine(StandardsDir, "code.md");
+        if (!File.Exists(standardsFile))
+        {
+            Out.Blank();
+            Out.Step("inferring standards...");
+            Out.Blank();
+
+            var standardsExitCode = await RunStandardsInference();
+            if (standardsExitCode != 0)
+            {
+                Out.Warn("standards inference skipped");
+            }
+            else
+            {
+                Out.Ok("standards created");
+            }
+        }
+        else
+        {
+            Out.Detail("standards already exist");
+        }
+
         Out.Blank();
         Out.Line();
         Out.Blank();
         Out.Ok("ready — run: mill spec");
         Out.Blank();
         Out.Detail("tip: run `mill personas` to define user segments for better specs");
+        Out.Detail("tip: run `mill standards` to refine inferred standards");
         Out.Blank();
 
         return 0;
@@ -807,6 +833,249 @@ static partial class Mill
 
         process.Start();
         process.WaitForExit();
+        return process.ExitCode;
+    }
+
+    public static int RunStandards()
+    {
+        if (!IsGitRepo())
+        {
+            Out.Error("not in a git repository");
+            return 1;
+        }
+
+        Out.Blank();
+
+        var standardsFile = Path.Combine(StandardsDir, "code.md");
+        var hasExisting = File.Exists(standardsFile);
+
+        if (hasExisting)
+        {
+            Out.Ok("existing standards found");
+            Out.Detail("you can update, add, or regenerate");
+        }
+        else
+        {
+            Out.Step("no standards yet — starting inference");
+        }
+
+        Out.Blank();
+
+        return RunClaudeInteractiveStandards("spec/prompts/standards-infer.md", hasExisting);
+    }
+
+    static int RunClaudeInteractiveStandards(string promptPath, bool hasExistingStandards)
+    {
+        var fullPath = Path.Combine(FindMillHome(), promptPath);
+        if (!File.Exists(fullPath))
+        {
+            Out.Error($"prompt not found: {fullPath}");
+            return 1;
+        }
+
+        var cli = ResolveCli();
+
+        // Build prompt with pre-loaded context for standards inference
+        var prompt = new System.Text.StringBuilder();
+        prompt.AppendLine(File.ReadAllText(fullPath));
+
+        prompt.AppendLine("\n---\n# Pre-loaded Context\n");
+
+        // context.md if available
+        if (File.Exists(ContextFile))
+        {
+            prompt.AppendLine("## .mill/context.md\n");
+            prompt.AppendLine(File.ReadAllText(ContextFile));
+        }
+
+        // AGENTS.md for project context
+        var agentsPath = Path.Combine(GitRoot, "AGENTS.md");
+        if (File.Exists(agentsPath))
+        {
+            prompt.AppendLine("\n## AGENTS.md\n");
+            prompt.AppendLine(File.ReadAllText(agentsPath));
+        }
+
+        // Existing standards for update mode
+        var standardsFile = Path.Combine(StandardsDir, "code.md");
+        if (File.Exists(standardsFile))
+        {
+            prompt.AppendLine("\n## Existing Standards (.mill/standards/code.md)\n");
+            prompt.AppendLine(File.ReadAllText(standardsFile));
+            prompt.AppendLine("\n**Mode:** Update existing standards based on new analysis or user input.");
+        }
+
+        // List config files that might contain standards
+        prompt.AppendLine("\n## Config Files Detected\n");
+        var configFiles = DetectConfigFiles();
+        if (configFiles.Count > 0)
+        {
+            foreach (var (name, content) in configFiles)
+            {
+                prompt.AppendLine($"### {name}\n```");
+                prompt.AppendLine(content.Length > 2000 ? content[..2000] + "\n... (truncated)" : content);
+                prompt.AppendLine("```\n");
+            }
+        }
+        else
+        {
+            prompt.AppendLine("No standard config files detected (.editorconfig, .eslintrc, etc.)");
+        }
+
+        var promptContent = prompt.ToString();
+
+        // Write to .mill/.prompt to avoid command line length limits
+        var promptFile = Path.Combine(CurrentMillDir, ".prompt");
+        Directory.CreateDirectory(CurrentMillDir);
+        File.WriteAllText(promptFile, promptContent);
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = cli,
+                RedirectStandardInput = false,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false,
+                UseShellExecute = false
+            }
+        };
+
+        process.StartInfo.ArgumentList.Add("--dangerously-skip-permissions");
+        process.StartInfo.ArgumentList.Add("--append-system-prompt");
+        process.StartInfo.ArgumentList.Add($"CRITICAL: Before responding, read {promptFile} for your full system context.");
+
+        // Initial message based on mode
+        var initialMessage = hasExistingStandards
+            ? "review and update these standards"
+            : "infer standards from this codebase";
+        process.StartInfo.ArgumentList.Add(initialMessage);
+
+        process.Start();
+        process.WaitForExit();
+        return process.ExitCode;
+    }
+
+    static List<(string Name, string Content)> DetectConfigFiles()
+    {
+        var configFiles = new List<(string Name, string Content)>();
+        var configPatterns = new[]
+        {
+            ".editorconfig",
+            ".eslintrc",
+            ".eslintrc.js",
+            ".eslintrc.json",
+            ".eslintrc.yml",
+            "eslint.config.js",
+            "eslint.config.mjs",
+            ".prettierrc",
+            ".prettierrc.js",
+            ".prettierrc.json",
+            "prettier.config.js",
+            "stylecop.json",
+            ".stylecop",
+            "tsconfig.json",
+            "biome.json",
+            ".rubocop.yml",
+            "pyproject.toml",
+            "setup.cfg",
+            ".flake8",
+            "go.mod"
+        };
+
+        foreach (var pattern in configPatterns)
+        {
+            var path = Path.Combine(GitRoot, pattern);
+            if (File.Exists(path))
+            {
+                try
+                {
+                    configFiles.Add((pattern, File.ReadAllText(path)));
+                }
+                catch { }
+            }
+        }
+
+        return configFiles;
+    }
+
+    /// <summary>
+    /// Run standards inference in non-interactive streaming mode (for mill init).
+    /// Creates .mill/standards/code.md with inferred rules.
+    /// </summary>
+    static async Task<int> RunStandardsInference()
+    {
+        var promptPath = Path.Combine(FindMillHome(), "spec/prompts/standards-infer.md");
+        if (!File.Exists(promptPath))
+        {
+            Out.Error($"standards prompt not found: {promptPath}");
+            return 1;
+        }
+
+        // Build the prompt with context
+        var prompt = new System.Text.StringBuilder();
+        prompt.AppendLine(File.ReadAllText(promptPath));
+        prompt.AppendLine("\n---\n# Pre-loaded Context\n");
+
+        // context.md if available
+        if (File.Exists(ContextFile))
+        {
+            prompt.AppendLine("## .mill/context.md\n");
+            prompt.AppendLine(File.ReadAllText(ContextFile));
+        }
+
+        // AGENTS.md for project context
+        var agentsPath = Path.Combine(GitRoot, "AGENTS.md");
+        if (File.Exists(agentsPath))
+        {
+            prompt.AppendLine("\n## AGENTS.md\n");
+            prompt.AppendLine(File.ReadAllText(agentsPath));
+        }
+
+        // List config files
+        prompt.AppendLine("\n## Config Files Detected\n");
+        var configFiles = DetectConfigFiles();
+        if (configFiles.Count > 0)
+        {
+            foreach (var (name, content) in configFiles)
+            {
+                prompt.AppendLine($"### {name}\n```");
+                prompt.AppendLine(content.Length > 2000 ? content[..2000] + "\n... (truncated)" : content);
+                prompt.AppendLine("```\n");
+            }
+        }
+        else
+        {
+            prompt.AppendLine("No standard config files detected (.editorconfig, .eslintrc, etc.)");
+        }
+
+        // Add auto-inference instruction
+        prompt.AppendLine("\n---\n# Auto-Inference Mode\n");
+        prompt.AppendLine("This is running during `mill init`. Generate standards non-interactively:");
+        prompt.AppendLine("1. Detect config files and analyze codebase patterns");
+        prompt.AppendLine("2. Generate `.mill/standards/code.md` with inferred rules");
+        prompt.AppendLine("3. If no clear patterns found, create minimal standards with placeholders");
+        prompt.AppendLine("4. Do NOT ask questions — just infer and write");
+
+        var cli = ResolveCli();
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = cli,
+                Arguments = "-p --dangerously-skip-permissions",
+                RedirectStandardInput = true,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false,
+                UseShellExecute = false
+            }
+        };
+
+        process.Start();
+        await process.StandardInput.WriteAsync(prompt.ToString());
+        process.StandardInput.Close();
+        await process.WaitForExitAsync();
+
         return process.ExitCode;
     }
 

--- a/cli/mill-cli.csproj
+++ b/cli/mill-cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Mill</RootNamespace>
     <AssemblyName>mill</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/spec/prompts/standards-infer.md
+++ b/spec/prompts/standards-infer.md
@@ -1,0 +1,265 @@
+# Standards
+
+Create or update codebase standards by detecting config files and inferring patterns from code.
+
+**CRITICAL:** Standards must be evidence-backed. Infer from actual codebase patterns and config files, not generic templates.
+
+## Purpose
+
+Standards created here are loaded during `mill run` to guide implementation:
+- Consistent formatting and style
+- Naming conventions aligned with existing code
+- Architecture patterns the codebase follows
+- Build/test requirements
+
+## Context
+Pre-loaded: `.mill/context.md`, `.mill/standards/code.md` (if exists), config files detected.
+
+## Flow
+
+### 1. Check Existing Standards
+
+If `.mill/standards/code.md` exists, show summary:
+
+```
+found existing standards:
+
+sections:
+- [section name] ({n} rules)
+- [section name] ({n} rules)
+
+what would you like to do? (update, add, regenerate, or review)
+```
+
+Accept natural language. Examples:
+- "update" → Update Flow
+- "add naming rules" → Add specific section
+- "regenerate" → confirm → Infer Flow
+- "review" → show full content
+
+If no existing standards, go directly to Infer Flow.
+
+---
+
+### Infer Flow (detect and generate standards)
+
+#### 1a. Detect Config Files
+
+Search for standard config files:
+
+```bash
+# List files in root that might contain standards
+ls -la | grep -E '\.(editorconfig|eslintrc|prettierrc|stylecop)' || true
+ls -la *.json 2>/dev/null | grep -E '(tsconfig|stylecop|biome)' || true
+```
+
+Also check for:
+- `.editorconfig` — indentation, line endings
+- `.eslintrc.*`, `eslint.config.*` — JS/TS linting
+- `.prettierrc*`, `prettier.config.*` — formatting
+- `stylecop.json`, `.stylecop` — C# style
+- `tsconfig.json` — TypeScript config
+- `biome.json` — Biome linter/formatter
+- `.rubocop.yml` — Ruby style
+- `pyproject.toml`, `setup.cfg` — Python config
+- `go.mod` — Go module info
+- `Makefile`, `justfile` — build conventions
+
+Read each found config and extract relevant rules.
+
+#### 1b. Analyze Codebase Patterns
+
+Sample code files to infer patterns:
+
+```bash
+# Find main source files
+git ls-files | grep -E '\.(cs|ts|js|py|go|rb|rs)$' | head -10
+```
+
+For each language detected, analyze:
+- **Indentation** — tabs vs spaces, width
+- **Naming** — PascalCase, camelCase, snake_case for different constructs
+- **Imports** — order, grouping
+- **Comments** — style, documentation patterns
+- **Architecture** — directory structure, module patterns
+
+#### 1c. Summarize Findings
+
+Present detected standards:
+
+```
+detected from config files:
+- [source]: [rule summary]
+- [source]: [rule summary]
+
+inferred from codebase:
+- [pattern]: [evidence]
+- [pattern]: [evidence]
+
+anything to add or change? (yes / proceed / skip [category])
+```
+
+Accept modifications before generating.
+
+#### 1d. Generate Standards
+
+Create `.mill/standards/code.md` with discovered rules.
+
+---
+
+### Update Flow (modify existing standards)
+
+Show current section, ask what to change:
+
+```
+[section name]:
+- rule 1
+- rule 2
+
+what would you like to change? (add rule / remove rule / reword)
+```
+
+After changes: "save? (yes / change more / discard)"
+
+---
+
+### Add Flow (add new section or rules)
+
+```
+what kind of standards? (naming, formatting, architecture, testing, or describe)
+```
+
+Elicit specifics, then:
+```
+new rules:
+
+[section]:
+- [rule]
+- [rule]
+
+add these? (yes / edit / cancel)
+```
+
+---
+
+## Standards Template
+
+Organized by category, evidence-backed.
+
+```markdown
+<!-- mill-standards: {hash} -->
+<!-- updated: {timestamp} -->
+<!-- sources: {list of config files} -->
+
+# Code Standards
+
+## Formatting
+{Rules about indentation, line length, etc.}
+
+## Naming
+{Naming conventions for types, methods, variables, files}
+
+## Architecture
+{Directory structure, module patterns, dependencies}
+
+## Documentation
+{Comment style, when to document}
+
+## Testing
+{Test file naming, coverage expectations}
+
+---
+*Detected from: {sources}*
+```
+
+---
+
+## Detection Priority
+
+When configs conflict with code patterns, trust configs over inferred patterns.
+
+1. **Explicit config files** — `.editorconfig`, `.eslintrc`, etc.
+2. **Project conventions** — `AGENTS.md`, `README.md` style notes
+3. **Inferred from code** — patterns observed in existing files
+
+---
+
+## File Format
+
+`.mill/standards/code.md` structure:
+
+```markdown
+<!-- mill-standards: abc123 -->
+<!-- updated: 2025-01-20T14:30:00Z -->
+<!-- sources: .editorconfig, tsconfig.json -->
+
+# Code Standards
+
+## Formatting
+
+- Use 4 spaces for indentation (from .editorconfig)
+- Max line length: 120 characters
+- UTF-8 encoding, LF line endings
+
+## Naming
+
+- **Types:** PascalCase (`UserService`, `HttpRequest`)
+- **Methods:** PascalCase for C#, camelCase for JS/TS
+- **Variables:** camelCase
+- **Constants:** UPPER_SNAKE_CASE
+- **Files:** kebab-case for scripts, PascalCase for classes
+
+## Architecture
+
+- CLI commands in `cli/Program.cs`
+- Prompts in `spec/prompts/` and `run/prompts/`
+- Templates in `spec/templates/`
+
+## Documentation
+
+- Use `///` XML docs for public APIs in C#
+- Minimal comments — code should be self-documenting
+- Diagrams must use Mermaid, not ASCII art
+
+---
+*Detected from: .editorconfig, tsconfig.json, cli/Program.cs patterns*
+```
+
+---
+
+## Save Flow
+
+After save:
+```
+saved .mill/standards/code.md
+
+detected: {n} rules from config
+inferred: {n} rules from code
+
+anything else? (update / done)
+```
+
+On "done":
+```
+done. standards will be loaded during `mill run`.
+```
+
+---
+
+## Rules
+
+1. **Evidence-first** — every rule needs a source (config file, code pattern, or user input)
+2. **Config wins** — explicit config files override inferred patterns
+3. **Be specific** — "use 4 spaces" not "use consistent indentation"
+4. **Language-aware** — group by language if multi-language project
+5. **No aspirational rules** — only document what the codebase actually does
+6. **Preserve existing** — update mode merges, doesn't replace
+7. **Confirm destructive actions** — regenerate needs explicit y/n
+
+## Anti-patterns
+
+- "Follow best practices" — too vague, cite specific rules
+- Rules the codebase doesn't follow — standards document reality
+- Long explanations — keep rules to one line
+- Duplicate rules from different sources — dedupe and cite primary
+- Inventing conventions — only document what exists


### PR DESCRIPTION
Fixes #3

## Summary
Added auto-generation of codebase standards during `mill init` and interactive refinement via `mill standards` command. Standards are inferred from config files (.editorconfig, .eslintrc, tsconfig.json, etc.) and codebase patterns. Idempotent: existing standards are preserved on re-run.

## Verification
dotnet build cli/mill-cli.csproj - 0 warnings, 0 errors. All 4 acceptance criteria met: auto-inference during init, config file detection, standards command exists, idempotent updates.