### PR TITLE
#4: sweep command for codebase analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ CLAUDE.md             # Shim (@AGENTS.md) — AGENTS.md is source of truth
 
 # MILL ephemeral
 .mill/.prompt
+.mill/memory/issue-*-plan.md

--- a/.mill/memory/issue-4-plan.md
+++ b/.mill/memory/issue-4-plan.md
@@ -1,0 +1,13 @@
+# Slice Plan for #4
+
+## Concerns
+- [x] Model - data structures for sweep findings and categories
+- [x] Logic - sweep prompt, issue creation, dismissal tracking
+- [x] Interface - `mill sweep` command, interactive prompts
+
+## Slice Order
+1. **Model** - Define data structures: `SweepFinding`, `SweepCategory`, JSON contexts. Add `sweep` and `impact:low` labels to `RequiredLabels`. This is first because other slices depend on the data model.
+2. **Logic** - Create `sweep-analyze.md` prompt for Claude to analyze codebase against standards. Implement helper methods for: fetching existing sweep issues, reading dismissed findings from `project.md`, creating issues via `gh`.
+3. **Interface** - Implement `RunSweep()` command with interactive flow: display findings by category, prompt for selection (`1,2,3`, `all`, `none`), dismissal confirmation, issue creation.
+
+## Current: Complete

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ Benefits:
 
 ## Development Notes
 
+- **Cross-platform:** Windows, Linux, macOS (x64/arm64) — use `OperatingSystem.IsWindows()` etc. for platform-specific code
 - **Do not run `dotnet publish`** after each change — the user will build periodically when needed
 
 ## Documentation Standards

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -519,6 +519,96 @@ static partial class Mill
         return success && RequiredLabels.All(existing.Contains);
     }
 
+    /// <summary>
+    /// Gets existing open sweep issues to avoid creating duplicates.
+    /// Returns a set of finding IDs that already have open issues.
+    /// </summary>
+    static HashSet<string> GetExistingSweepIssues()
+    {
+        var (exit, output) = Gh("issue", "list", "--state", "open", "--label", "sweep", "--json", "body", "--limit", "100");
+        if (exit != 0) return [];
+
+        var issues = JsonSerializer.Deserialize(output, GhJsonContext.Default.ListGhIssueDetail) ?? [];
+        var existingIds = new HashSet<string>();
+
+        foreach (var issue in issues)
+        {
+            if (string.IsNullOrEmpty(issue.Body)) continue;
+
+            // Extract finding ID from issue body (format: "Finding: `dry-001`" or similar)
+            var match = Regex.Match(issue.Body, @"Finding:\s*`?([a-z]+-\d+)`?", RegexOptions.IgnoreCase);
+            if (match.Success)
+                existingIds.Add(match.Groups[1].Value.ToLowerInvariant());
+        }
+
+        return existingIds;
+    }
+
+    /// <summary>
+    /// Reads dismissed findings from project memory.
+    /// Returns a set of finding IDs that have been dismissed by the user.
+    /// </summary>
+    static HashSet<string> ReadDismissedFindings()
+    {
+        var projectMemory = Path.Combine(MemoryDir, "project.md");
+        if (!File.Exists(projectMemory)) return [];
+
+        var content = File.ReadAllText(projectMemory);
+        var dismissed = new HashSet<string>();
+
+        // Look for dismissed findings section
+        var match = Regex.Match(content, @"## Dismissed Findings\s*\n((?:- .+\n?)+)", RegexOptions.IgnoreCase);
+        if (!match.Success) return dismissed;
+
+        // Extract each dismissed finding ID
+        var section = match.Groups[1].Value;
+        foreach (Match idMatch in Regex.Matches(section, @"- `?([a-z]+-\d+)`?", RegexOptions.IgnoreCase))
+        {
+            dismissed.Add(idMatch.Groups[1].Value.ToLowerInvariant());
+        }
+
+        return dismissed;
+    }
+
+    /// <summary>
+    /// Appends dismissed findings to project memory.
+    /// </summary>
+    static void SaveDismissedFindings(IEnumerable<string> findingIds)
+    {
+        var projectMemory = Path.Combine(MemoryDir, "project.md");
+        Directory.CreateDirectory(MemoryDir);
+
+        var content = File.Exists(projectMemory) ? File.ReadAllText(projectMemory) : "";
+
+        // Check if dismissed findings section exists
+        if (content.Contains("## Dismissed Findings"))
+        {
+            // Append to existing section
+            var lines = findingIds.Select(id => $"- `{id}`");
+            var insertion = string.Join("\n", lines) + "\n";
+
+            // Find the end of the section and insert
+            var sectionEnd = content.IndexOf("\n## ", content.IndexOf("## Dismissed Findings") + 1);
+            if (sectionEnd == -1)
+            {
+                // Section is at the end of file
+                content = content.TrimEnd() + "\n" + insertion;
+            }
+            else
+            {
+                content = content.Insert(sectionEnd, insertion);
+            }
+        }
+        else
+        {
+            // Create new section
+            var section = "\n## Dismissed Findings\n\n" + string.Join("\n", findingIds.Select(id => $"- `{id}`")) + "\n";
+            content = content.TrimEnd() + section;
+        }
+
+        File.WriteAllText(projectMemory, content);
+    }
+
     public static async Task<int> RunSpec()
     {
         if (!IsGitRepo())
@@ -2850,6 +2940,7 @@ record HealthConfig
 
 [JsonSerializable(typeof(List<GhIssue>))]
 [JsonSerializable(typeof(GhIssueDetail))]
+[JsonSerializable(typeof(List<GhIssueDetail>))]
 [JsonSerializable(typeof(GhIssueDetailFull))]
 [JsonSerializable(typeof(GhRelease))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -23,6 +23,7 @@ return args switch
     ["spec", ..] => await Mill.RunSpec(),
     ["personas"] => Mill.RunPersonas(),
     ["standards"] => Mill.RunStandards(),
+    ["sweep"] => await Mill.RunSweep(),
     ["run", "--auto"] => await Mill.RunAutopick(),
     ["run", "-a"] => await Mill.RunAutopick(),
     ["run", var issue, ..] => await Mill.Execute(issue, args),
@@ -1179,6 +1180,274 @@ static partial class Mill
         await process.WaitForExitAsync();
 
         return process.ExitCode;
+    }
+
+    /// <summary>
+    /// Scan codebase against standards, surface findings, and optionally create GitHub issues.
+    /// </summary>
+    public static async Task<int> RunSweep()
+    {
+        if (!IsGitRepo())
+        {
+            Out.Error("not in a git repository");
+            return 1;
+        }
+
+        if (!IsInitialized())
+        {
+            Out.Warn("mill not initialized — run: mill init");
+            return 1;
+        }
+
+        // Check for standards
+        var standardsFile = Path.Combine(StandardsDir, "code.md");
+        if (!File.Exists(standardsFile))
+        {
+            Out.Blank();
+            Out.Warn("no standards defined");
+            Out.Detail("sweep requires standards to check against");
+            Out.Blank();
+            Console.WriteLine("  run: mill init      (infers standards during setup)");
+            Console.WriteLine("  or:  mill standards (create/edit standards manually)");
+            Out.Blank();
+            return 1;
+        }
+
+        Out.Blank();
+        Out.Step("analyzing codebase against standards...");
+        Out.Blank();
+
+        // Run Claude to analyze the codebase
+        var sweepPromptPath = Path.Combine(FindMillHome(), "run/prompts/sweep-analyze.md");
+        if (!File.Exists(sweepPromptPath))
+        {
+            Out.Error($"sweep prompt not found: {sweepPromptPath}");
+            return 1;
+        }
+
+        // Build the prompt with standards content
+        var template = await File.ReadAllTextAsync(sweepPromptPath);
+        var standardsContent = await File.ReadAllTextAsync(standardsFile);
+        var rendered = template.Replace("{{STANDARDS_CONTENT}}", standardsContent);
+
+        // Run Claude and capture output
+        var cli = RequireCli();
+        if (cli == null) return 1;
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = cli,
+                Arguments = "-p --dangerously-skip-permissions --output-format text",
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = false, // Let errors go to console
+                UseShellExecute = false
+            }
+        };
+
+        process.Start();
+        await process.StandardInput.WriteAsync(rendered);
+        process.StandardInput.Close();
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            Out.Error("analysis failed");
+            return 1;
+        }
+
+        // Parse the JSON output
+        var analysisMatch = Regex.Match(output, @"SWEEP_ANALYSIS\s*(\{[\s\S]*\})", RegexOptions.Multiline);
+        if (!analysisMatch.Success)
+        {
+            Out.Warn("could not parse analysis output");
+            Out.Detail("check the sweep-analyze prompt format");
+            return 1;
+        }
+
+        SweepAnalysis? analysis;
+        try
+        {
+            analysis = JsonSerializer.Deserialize(analysisMatch.Groups[1].Value, GhJsonContext.Default.SweepAnalysis);
+        }
+        catch (JsonException ex)
+        {
+            Out.Error($"invalid analysis JSON: {ex.Message}");
+            return 1;
+        }
+
+        if (analysis == null || analysis.Categories.Count == 0)
+        {
+            Out.Blank();
+            Out.Ok("no findings — codebase looks good!");
+            Out.Blank();
+            return 0;
+        }
+
+        // Load existing sweep issues and dismissed findings to filter
+        var existingIssues = GetExistingSweepIssues();
+        var dismissed = ReadDismissedFindings();
+
+        // Filter findings per category
+        var filteredCategories = new List<SweepCategory>();
+        foreach (var category in analysis.Categories)
+        {
+            var filtered = category.Findings
+                .Where(f => !existingIssues.Contains(f.Id.ToLowerInvariant()))
+                .Where(f => !dismissed.Contains(f.Id.ToLowerInvariant()))
+                .ToList();
+
+            if (filtered.Count > 0)
+            {
+                filteredCategories.Add(category with { Findings = filtered });
+            }
+        }
+
+        if (filteredCategories.Count == 0)
+        {
+            Out.Blank();
+            Out.Ok("no new findings (existing issues or dismissed)");
+            Out.Blank();
+            return 0;
+        }
+
+        // Interactive selection per category
+        var selectedFindings = new List<SweepFinding>();
+        var toDismiss = new List<string>();
+
+        Out.Blank();
+        Console.WriteLine($"  found {filteredCategories.Sum(c => c.Findings.Count)} findings in {filteredCategories.Count} categories");
+        Out.Blank();
+
+        foreach (var category in filteredCategories)
+        {
+            Out.Line();
+            Out.Blank();
+            Console.WriteLine($"  {category.Name}");
+            if (!string.IsNullOrEmpty(category.Description))
+                Out.Detail(category.Description);
+            Out.Blank();
+
+            // Display numbered findings
+            for (var i = 0; i < category.Findings.Count; i++)
+            {
+                var f = category.Findings[i];
+                var severity = f.Severity?.ToLowerInvariant() switch
+                {
+                    "high" => "[high]",
+                    "medium" => "[med]",
+                    _ => "[low]"
+                };
+                Console.WriteLine($"    {i + 1}. {severity,-6} {f.Title}");
+                if (!string.IsNullOrEmpty(f.File))
+                    Out.Detail($"{f.File}" + (f.Line > 0 ? $":{f.Line}" : ""));
+            }
+
+            Out.Blank();
+            Out.Prompt($"create issues [1-{category.Findings.Count}, all, none] (enter to skip): ");
+
+            var input = Console.ReadLine()?.Trim().ToLowerInvariant() ?? "";
+            // Clear line and reprint without blink
+            Console.Write($"\r\x1b[2K  ❯ selection: {(string.IsNullOrEmpty(input) ? "skip" : input)}");
+            Console.WriteLine();
+
+            if (string.IsNullOrEmpty(input))
+            {
+                // Default: skip
+                continue;
+            }
+            else if (input == "all")
+            {
+                selectedFindings.AddRange(category.Findings);
+            }
+            else if (input == "none")
+            {
+                // Prompt to remember as dismissed
+                if (Out.Confirm("remember as dismissed?"))
+                {
+                    toDismiss.AddRange(category.Findings.Select(f => f.Id));
+                }
+            }
+            else
+            {
+                // Parse comma-separated numbers
+                var indices = input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(s => int.TryParse(s, out var n) ? n : -1)
+                    .Where(n => n >= 1 && n <= category.Findings.Count)
+                    .Distinct()
+                    .ToList();
+
+                foreach (var idx in indices)
+                {
+                    selectedFindings.Add(category.Findings[idx - 1]);
+                }
+            }
+        }
+
+        // Save dismissed findings
+        if (toDismiss.Count > 0)
+        {
+            SaveDismissedFindings(toDismiss);
+            Out.Blank();
+            Out.Ok($"dismissed {toDismiss.Count} findings");
+        }
+
+        // Create issues for selected findings
+        if (selectedFindings.Count == 0)
+        {
+            Out.Blank();
+            Out.Ok("no issues created");
+            Out.Blank();
+            return 0;
+        }
+
+        Out.Blank();
+        Out.Step($"creating {selectedFindings.Count} issues...");
+        Out.Blank();
+
+        var created = 0;
+        foreach (var finding in selectedFindings)
+        {
+            var title = $"[sweep] {finding.Title}";
+            var body = $"""
+                **Finding:** `{finding.Id}`
+
+                {finding.Description}
+
+                **Location:** {finding.File ?? "N/A"}{(finding.Line > 0 ? $":{finding.Line}" : "")}
+                **Severity:** {finding.Severity ?? "low"}
+
+                ---
+                *Generated by `mill sweep`*
+                """;
+
+            var (exitCode, _) = Gh("issue", "create",
+                "--title", title,
+                "--body", body,
+                "--label", "task",
+                "--label", "impact:low",
+                "--label", "sweep");
+
+            if (exitCode == 0)
+            {
+                created++;
+                Out.Detail($"created: {finding.Title}");
+            }
+            else
+            {
+                Out.Warn($"failed: {finding.Title}");
+            }
+        }
+
+        Out.Blank();
+        Out.Ok($"{created} issues created");
+        Out.Detail("run: mill run to see available issues");
+        Out.Blank();
+
+        return 0;
     }
 
     static string? PromptForDraft()
@@ -2924,6 +3193,7 @@ record HealthConfig
 [JsonSerializable(typeof(List<GhIssueDetail>))]
 [JsonSerializable(typeof(GhIssueDetailFull))]
 [JsonSerializable(typeof(GhRelease))]
+[JsonSerializable(typeof(SweepAnalysis))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class GhJsonContext : JsonSerializerContext { }
 

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -1387,7 +1387,10 @@ static partial class Mill
                     if (!string.IsNullOrEmpty(testCommand))
                     {
                         Out.Step($"running tests: {testCommand}");
-                        var (testExit, testOut, testErr) = Run("sh", "-c", testCommand);
+                        var (shellCmd, shellArg) = OperatingSystem.IsWindows()
+                            ? (FindInPath("pwsh") != null ? ("pwsh", "-c") : ("powershell.exe", "-Command"))
+                            : ("sh", "-c");
+                        var (testExit, testOut, testErr) = Run(shellCmd, shellArg, testCommand);
                         if (testExit != 0)
                         {
                             Out.Blank();

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -1315,6 +1315,25 @@ static partial class Mill
             // Change to worktree directory
             Directory.SetCurrentDirectory(Path.Combine(originalDir, worktreePath));
 
+            // Try to copy parent's context.md if hash matches worktree HEAD
+            var parentContextFile = Path.Combine(ParentMillDir, "context.md");
+            if (File.Exists(parentContextFile))
+            {
+                var firstLine = File.ReadLines(parentContextFile).FirstOrDefault() ?? "";
+                var match = HashPattern().Match(firstLine);
+                if (match.Success)
+                {
+                    var parentHash = match.Groups[1].Value;
+                    var worktreeHead = Git("rev-parse", "HEAD").Output.Trim();
+                    if (parentHash == worktreeHead)
+                    {
+                        Directory.CreateDirectory(CurrentMillDir);
+                        File.Copy(parentContextFile, ContextFile, overwrite: true);
+                        Out.Ok("context inherited from parent");
+                    }
+                }
+            }
+
             // Ensure context exists in worktree (uses CurrentMillDir which resolves to worktree)
             var (needsWarmup, reason) = CheckContextStaleness();
             if (needsWarmup)

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -23,6 +23,7 @@ return args switch
     ["spec", ..] => await Mill.RunSpec(),
     ["personas"] => Mill.RunPersonas(),
     ["standards"] => Mill.RunStandards(),
+    ["sweep"] => await Mill.RunSweep(),
     ["run", "--auto"] => await Mill.RunAutopick(),
     ["run", "-a"] => await Mill.RunAutopick(),
     ["run", var issue, ..] => await Mill.Execute(issue, args),
@@ -1179,6 +1180,274 @@ static partial class Mill
         await process.WaitForExitAsync();
 
         return process.ExitCode;
+    }
+
+    /// <summary>
+    /// Scan codebase against standards, surface findings, and optionally create GitHub issues.
+    /// </summary>
+    public static async Task<int> RunSweep()
+    {
+        if (!IsGitRepo())
+        {
+            Out.Error("not in a git repository");
+            return 1;
+        }
+
+        if (!IsInitialized())
+        {
+            Out.Warn("mill not initialized — run: mill init");
+            return 1;
+        }
+
+        // Check for standards
+        var standardsFile = Path.Combine(StandardsDir, "code.md");
+        if (!File.Exists(standardsFile))
+        {
+            Out.Blank();
+            Out.Warn("no standards defined");
+            Out.Detail("sweep requires standards to check against");
+            Out.Blank();
+            Console.WriteLine("  run: mill init      (infers standards during setup)");
+            Console.WriteLine("  or:  mill standards (create/edit standards manually)");
+            Out.Blank();
+            return 1;
+        }
+
+        Out.Blank();
+        Out.Step("analyzing codebase against standards...");
+        Out.Blank();
+
+        // Run Claude to analyze the codebase
+        var sweepPromptPath = Path.Combine(FindMillHome(), "run/prompts/sweep-analyze.md");
+        if (!File.Exists(sweepPromptPath))
+        {
+            Out.Error($"sweep prompt not found: {sweepPromptPath}");
+            return 1;
+        }
+
+        // Build the prompt with standards content
+        var template = await File.ReadAllTextAsync(sweepPromptPath);
+        var standardsContent = await File.ReadAllTextAsync(standardsFile);
+        var rendered = template.Replace("{{STANDARDS_CONTENT}}", standardsContent);
+
+        // Run Claude and capture output
+        var cli = RequireCli();
+        if (cli == null) return 1;
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = cli,
+                Arguments = "-p --dangerously-skip-permissions --output-format text",
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = false, // Let errors go to console
+                UseShellExecute = false
+            }
+        };
+
+        process.Start();
+        await process.StandardInput.WriteAsync(rendered);
+        process.StandardInput.Close();
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            Out.Error("analysis failed");
+            return 1;
+        }
+
+        // Parse the JSON output
+        var analysisMatch = Regex.Match(output, @"SWEEP_ANALYSIS\s*(\{[\s\S]*\})", RegexOptions.Multiline);
+        if (!analysisMatch.Success)
+        {
+            Out.Warn("could not parse analysis output");
+            Out.Detail("check the sweep-analyze prompt format");
+            return 1;
+        }
+
+        SweepAnalysis? analysis;
+        try
+        {
+            analysis = JsonSerializer.Deserialize(analysisMatch.Groups[1].Value, GhJsonContext.Default.SweepAnalysis);
+        }
+        catch (JsonException ex)
+        {
+            Out.Error($"invalid analysis JSON: {ex.Message}");
+            return 1;
+        }
+
+        if (analysis == null || analysis.Categories.Count == 0)
+        {
+            Out.Blank();
+            Out.Ok("no findings — codebase looks good!");
+            Out.Blank();
+            return 0;
+        }
+
+        // Load existing sweep issues and dismissed findings to filter
+        var existingIssues = GetExistingSweepIssues();
+        var dismissed = ReadDismissedFindings();
+
+        // Filter findings per category
+        var filteredCategories = new List<SweepCategory>();
+        foreach (var category in analysis.Categories)
+        {
+            var filtered = category.Findings
+                .Where(f => !existingIssues.Contains(f.Id.ToLowerInvariant()))
+                .Where(f => !dismissed.Contains(f.Id.ToLowerInvariant()))
+                .ToList();
+
+            if (filtered.Count > 0)
+            {
+                filteredCategories.Add(category with { Findings = filtered });
+            }
+        }
+
+        if (filteredCategories.Count == 0)
+        {
+            Out.Blank();
+            Out.Ok("no new findings (existing issues or dismissed)");
+            Out.Blank();
+            return 0;
+        }
+
+        // Interactive selection per category
+        var selectedFindings = new List<SweepFinding>();
+        var toDismiss = new List<string>();
+
+        Out.Blank();
+        Console.WriteLine($"  found {filteredCategories.Sum(c => c.Findings.Count)} findings in {filteredCategories.Count} categories");
+        Out.Blank();
+
+        foreach (var category in filteredCategories)
+        {
+            Out.Line();
+            Out.Blank();
+            Console.WriteLine($"  {category.Name}");
+            if (!string.IsNullOrEmpty(category.Description))
+                Out.Detail(category.Description);
+            Out.Blank();
+
+            // Display numbered findings
+            for (var i = 0; i < category.Findings.Count; i++)
+            {
+                var f = category.Findings[i];
+                var severity = f.Severity?.ToLowerInvariant() switch
+                {
+                    "high" => "[high]",
+                    "medium" => "[med]",
+                    _ => "[low]"
+                };
+                Console.WriteLine($"    {i + 1}. {severity,-6} {f.Title}");
+                if (!string.IsNullOrEmpty(f.File))
+                    Out.Detail($"{f.File}" + (f.Line > 0 ? $":{f.Line}" : ""));
+            }
+
+            Out.Blank();
+            Out.Prompt($"create issues [1-{category.Findings.Count}, all, none] (enter to skip): ");
+
+            var input = Console.ReadLine()?.Trim().ToLowerInvariant() ?? "";
+            // Clear line and reprint without blink
+            Console.Write($"\r\x1b[2K  ❯ selection: {(string.IsNullOrEmpty(input) ? "skip" : input)}");
+            Console.WriteLine();
+
+            if (string.IsNullOrEmpty(input))
+            {
+                // Default: skip
+                continue;
+            }
+            else if (input == "all")
+            {
+                selectedFindings.AddRange(category.Findings);
+            }
+            else if (input == "none")
+            {
+                // Prompt to remember as dismissed
+                if (Out.Confirm("remember as dismissed?"))
+                {
+                    toDismiss.AddRange(category.Findings.Select(f => f.Id));
+                }
+            }
+            else
+            {
+                // Parse comma-separated numbers
+                var indices = input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(s => int.TryParse(s, out var n) ? n : -1)
+                    .Where(n => n >= 1 && n <= category.Findings.Count)
+                    .Distinct()
+                    .ToList();
+
+                foreach (var idx in indices)
+                {
+                    selectedFindings.Add(category.Findings[idx - 1]);
+                }
+            }
+        }
+
+        // Save dismissed findings
+        if (toDismiss.Count > 0)
+        {
+            SaveDismissedFindings(toDismiss);
+            Out.Blank();
+            Out.Ok($"dismissed {toDismiss.Count} findings");
+        }
+
+        // Create issues for selected findings
+        if (selectedFindings.Count == 0)
+        {
+            Out.Blank();
+            Out.Ok("no issues created");
+            Out.Blank();
+            return 0;
+        }
+
+        Out.Blank();
+        Out.Step($"creating {selectedFindings.Count} issues...");
+        Out.Blank();
+
+        var created = 0;
+        foreach (var finding in selectedFindings)
+        {
+            var title = $"[sweep] {finding.Title}";
+            var body = $"""
+                **Finding:** `{finding.Id}`
+
+                {finding.Description}
+
+                **Location:** {finding.File ?? "N/A"}{(finding.Line > 0 ? $":{finding.Line}" : "")}
+                **Severity:** {finding.Severity ?? "low"}
+
+                ---
+                *Generated by `mill sweep`*
+                """;
+
+            var (exitCode, _) = Gh("issue", "create",
+                "--title", title,
+                "--body", body,
+                "--label", "task",
+                "--label", "impact:low",
+                "--label", "sweep");
+
+            if (exitCode == 0)
+            {
+                created++;
+                Out.Detail($"created: {finding.Title}");
+            }
+            else
+            {
+                Out.Warn($"failed: {finding.Title}");
+            }
+        }
+
+        Out.Blank();
+        Out.Ok($"{created} issues created");
+        Out.Detail("run: mill run to see available issues");
+        Out.Blank();
+
+        return 0;
     }
 
     static string? PromptForDraft()
@@ -2943,6 +3212,7 @@ record HealthConfig
 [JsonSerializable(typeof(List<GhIssueDetail>))]
 [JsonSerializable(typeof(GhIssueDetailFull))]
 [JsonSerializable(typeof(GhRelease))]
+[JsonSerializable(typeof(SweepAnalysis))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class GhJsonContext : JsonSerializerContext { }
 

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -318,7 +318,10 @@ static partial class Mill
         "feature",
         "bug",
         "security",
-        "task"
+        "task",
+        // Sweep labels
+        "sweep",
+        "impact:low"
     ];
 
     public static async Task<int> Init()
@@ -385,6 +388,8 @@ static partial class Mill
                     "bug" => "D73A4A",
                     "security" => "EE0701",
                     "chore" => "666666",
+                    "sweep" => "BFD4F2",
+                    "impact:low" => "C5DEF5",
                     _ => "CCCCCC"
                 };
                 Gh("label", "create", label, "--color", color, "--force");
@@ -2884,3 +2889,27 @@ record CriterionFail(
 [JsonSerializable(typeof(CriterionFail))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class CriterionJsonContext : JsonSerializerContext { }
+
+// Sweep analysis types
+record SweepFinding(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("file")] string? File,
+    [property: JsonPropertyName("line")] int? Line,
+    [property: JsonPropertyName("severity")] string Severity);
+
+record SweepCategory(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("findings")] List<SweepFinding> Findings);
+
+record SweepAnalysis(
+    [property: JsonPropertyName("categories")] List<SweepCategory> Categories);
+
+[JsonSerializable(typeof(SweepFinding))]
+[JsonSerializable(typeof(SweepCategory))]
+[JsonSerializable(typeof(SweepAnalysis))]
+[JsonSerializable(typeof(List<SweepCategory>))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class SweepJsonContext : JsonSerializerContext { }

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -318,7 +318,10 @@ static partial class Mill
         "feature",
         "bug",
         "security",
-        "task"
+        "task",
+        // Sweep labels
+        "sweep",
+        "impact:low"
     ];
 
     public static async Task<int> Init()
@@ -385,6 +388,8 @@ static partial class Mill
                     "bug" => "D73A4A",
                     "security" => "EE0701",
                     "chore" => "666666",
+                    "sweep" => "BFD4F2",
+                    "impact:low" => "C5DEF5",
                     _ => "CCCCCC"
                 };
                 Gh("label", "create", label, "--color", color, "--force");
@@ -2865,3 +2870,27 @@ record CriterionFail(
 [JsonSerializable(typeof(CriterionFail))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class CriterionJsonContext : JsonSerializerContext { }
+
+// Sweep analysis types
+record SweepFinding(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("file")] string? File,
+    [property: JsonPropertyName("line")] int? Line,
+    [property: JsonPropertyName("severity")] string Severity);
+
+record SweepCategory(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("findings")] List<SweepFinding> Findings);
+
+record SweepAnalysis(
+    [property: JsonPropertyName("categories")] List<SweepCategory> Categories);
+
+[JsonSerializable(typeof(SweepFinding))]
+[JsonSerializable(typeof(SweepCategory))]
+[JsonSerializable(typeof(SweepAnalysis))]
+[JsonSerializable(typeof(List<SweepCategory>))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class SweepJsonContext : JsonSerializerContext { }

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -519,6 +519,96 @@ static partial class Mill
         return success && RequiredLabels.All(existing.Contains);
     }
 
+    /// <summary>
+    /// Gets existing open sweep issues to avoid creating duplicates.
+    /// Returns a set of finding IDs that already have open issues.
+    /// </summary>
+    static HashSet<string> GetExistingSweepIssues()
+    {
+        var (exit, output) = Gh("issue", "list", "--state", "open", "--label", "sweep", "--json", "body", "--limit", "100");
+        if (exit != 0) return [];
+
+        var issues = JsonSerializer.Deserialize(output, GhJsonContext.Default.ListGhIssueDetail) ?? [];
+        var existingIds = new HashSet<string>();
+
+        foreach (var issue in issues)
+        {
+            if (string.IsNullOrEmpty(issue.Body)) continue;
+
+            // Extract finding ID from issue body (format: "Finding: `dry-001`" or similar)
+            var match = Regex.Match(issue.Body, @"Finding:\s*`?([a-z]+-\d+)`?", RegexOptions.IgnoreCase);
+            if (match.Success)
+                existingIds.Add(match.Groups[1].Value.ToLowerInvariant());
+        }
+
+        return existingIds;
+    }
+
+    /// <summary>
+    /// Reads dismissed findings from project memory.
+    /// Returns a set of finding IDs that have been dismissed by the user.
+    /// </summary>
+    static HashSet<string> ReadDismissedFindings()
+    {
+        var projectMemory = Path.Combine(MemoryDir, "project.md");
+        if (!File.Exists(projectMemory)) return [];
+
+        var content = File.ReadAllText(projectMemory);
+        var dismissed = new HashSet<string>();
+
+        // Look for dismissed findings section
+        var match = Regex.Match(content, @"## Dismissed Findings\s*\n((?:- .+\n?)+)", RegexOptions.IgnoreCase);
+        if (!match.Success) return dismissed;
+
+        // Extract each dismissed finding ID
+        var section = match.Groups[1].Value;
+        foreach (Match idMatch in Regex.Matches(section, @"- `?([a-z]+-\d+)`?", RegexOptions.IgnoreCase))
+        {
+            dismissed.Add(idMatch.Groups[1].Value.ToLowerInvariant());
+        }
+
+        return dismissed;
+    }
+
+    /// <summary>
+    /// Appends dismissed findings to project memory.
+    /// </summary>
+    static void SaveDismissedFindings(IEnumerable<string> findingIds)
+    {
+        var projectMemory = Path.Combine(MemoryDir, "project.md");
+        Directory.CreateDirectory(MemoryDir);
+
+        var content = File.Exists(projectMemory) ? File.ReadAllText(projectMemory) : "";
+
+        // Check if dismissed findings section exists
+        if (content.Contains("## Dismissed Findings"))
+        {
+            // Append to existing section
+            var lines = findingIds.Select(id => $"- `{id}`");
+            var insertion = string.Join("\n", lines) + "\n";
+
+            // Find the end of the section and insert
+            var sectionEnd = content.IndexOf("\n## ", content.IndexOf("## Dismissed Findings") + 1);
+            if (sectionEnd == -1)
+            {
+                // Section is at the end of file
+                content = content.TrimEnd() + "\n" + insertion;
+            }
+            else
+            {
+                content = content.Insert(sectionEnd, insertion);
+            }
+        }
+        else
+        {
+            // Create new section
+            var section = "\n## Dismissed Findings\n\n" + string.Join("\n", findingIds.Select(id => $"- `{id}`")) + "\n";
+            content = content.TrimEnd() + section;
+        }
+
+        File.WriteAllText(projectMemory, content);
+    }
+
     public static async Task<int> RunSpec()
     {
         if (!IsGitRepo())
@@ -2831,6 +2921,7 @@ record HealthConfig
 
 [JsonSerializable(typeof(List<GhIssue>))]
 [JsonSerializable(typeof(GhIssueDetail))]
+[JsonSerializable(typeof(List<GhIssueDetail>))]
 [JsonSerializable(typeof(GhIssueDetailFull))]
 [JsonSerializable(typeof(GhRelease))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/cli/mill-cli.csproj
+++ b/cli/mill-cli.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>mill</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.1.4-preview</Version>
+    <Version>0.2.0-alpha</Version>
 
     <!-- AOT -->
     <PublishAot>true</PublishAot>

--- a/run/prompts/sweep-analyze.md
+++ b/run/prompts/sweep-analyze.md
@@ -1,0 +1,107 @@
+# Sweep Analysis
+
+Analyze this codebase against its standards and surface findings for potential cleanup.
+
+**Output:** Structured JSON with findings by category.
+
+## Context
+
+- **Standards:** `.mill/standards/code.md` (loaded below)
+- **Config:** `.mill/config.json` (source filtering)
+- **Project:** `.mill/context.md` (codebase overview)
+
+## Standards to Check Against
+
+{{STANDARDS_CONTENT}}
+
+## Analysis Scope
+
+Scan project source code only. Exclude:
+- `node_modules/`, `vendor/`, `.git/`
+- Build outputs, generated files
+- Test fixtures and mock data
+- Third-party code
+
+## Finding Categories
+
+Organize findings into these categories:
+
+1. **DRY Violations** - Duplicated code, copy-paste patterns
+2. **Complexity** - Methods too long, deep nesting, high cyclomatic complexity
+3. **Naming** - Inconsistent naming, unclear identifiers
+4. **Architecture** - Layer violations, circular dependencies, misplaced code
+5. **Documentation** - Missing/stale docs, TODO/FIXME comments
+6. **Deprecated** - Old patterns, outdated APIs, legacy code
+
+## Output Format
+
+Return a JSON object with this structure:
+
+```json
+{
+  "categories": [
+    {
+      "name": "DRY Violations",
+      "description": "Code duplicated across files",
+      "findings": [
+        {
+          "id": "dry-001",
+          "title": "Duplicate validation logic",
+          "description": "Same email validation pattern in UserService and AuthController",
+          "file": "src/services/UserService.ts",
+          "line": 42,
+          "severity": "medium"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Field Definitions
+
+- **id**: Unique identifier (category-prefix + number, e.g., `dry-001`, `complexity-003`)
+- **title**: Short description (max 60 chars)
+- **description**: Full context (max 200 chars)
+- **file**: Path relative to repo root (null if N/A)
+- **line**: Line number (null if N/A)
+- **severity**: `low`, `medium`, or `high`
+
+## Guidelines
+
+1. **Evidence-based** - Only report findings you can point to in code
+2. **Actionable** - Each finding should have a clear fix
+3. **Standards-aligned** - Reference which standard is violated
+4. **De-duplicate** - Group similar issues, don't list every instance
+5. **Prioritize** - Report most impactful findings first within category
+6. **Skip empty categories** - Don't include categories with no findings
+
+## Analysis Process
+
+1. Read `.mill/standards/code.md` for rules to check
+2. Sample source files (`git ls-files | grep -E '\.(cs|ts|js|py|go)$'`)
+3. For each category:
+   - Identify patterns that violate standards
+   - Find specific examples in code
+   - Assess severity based on impact
+4. Output structured JSON
+
+## Output
+
+Wrap your analysis in a code block:
+
+```
+SWEEP_ANALYSIS
+{
+  "categories": [...]
+}
+```
+
+If no findings in any category, return:
+
+```
+SWEEP_ANALYSIS
+{
+  "categories": []
+}
+```


### PR DESCRIPTION
Fixes #4

## Summary
Implemented `mill sweep` command that scans codebase against standards, surfaces findings by category with interactive prompts, and creates GitHub issues for selected findings. Supports number selection, all/none, dismissal tracking, and duplicate detection.

## Verification
dotnet build cli/mill-cli.csproj - 0 warnings, 0 errors